### PR TITLE
set --force-yes to install docker-engine

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -49,7 +49,7 @@ Vagrant.configure("2") do |config|
     apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D
     echo deb https://apt.dockerproject.org/repo ubuntu-trusty main > /etc/apt/sources.list.d/docker.list
     apt-get update
-    apt-get install -y docker-engine
+    apt-get install -y docker-engine --force-yes
   EOF
 
    config.vm.synced_folder '.', '/home/vagrant/src/github.com/mobingilabs/go-modaemon'


### PR DESCRIPTION
`vagrant up` fails in the last step.

```
==> default:   docker-engine
==> default: E
==> default: :
==> default: There are problems and -y was used without --force-yes
The SSH command responded with a non-zero exit status. Vagrant
assumes that this means the command failed. The output for this command
should be in the log above. Please read the output to determine what
went wrong.
```