### PR TITLE
Use git command instead of git2go

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -32,18 +32,6 @@ Vagrant.configure("2") do |config|
     mkdir -p ~vagrant/src/github.com/mobingilabs/go-modaemon
     chown -R vagrant:vagrant ~vagrant/src
 
-    echo Installing libgit2 ...
-    if [ ! -f v0.24.2.tar.gz ]; then
-      wget -q https://github.com/libgit2/libgit2/archive/v0.24.2.tar.gz
-      tar zxvf v0.24.2.tar.gz
-      cd libgit2-0.24.2
-      mkdir build && cd build
-      cmake ..
-      cmake --build .
-      cmake .. -DCMAKE_INSTALL_PREFIX=/usr
-      cmake --build . --target install
-    fi
-
     apt-get install -y apt-transport-https ca-certificates
     apt-get install -y linux-image-extra-$(uname -r) linux-image-extra-virtual
     apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D

--- a/circle.yml
+++ b/circle.yml
@@ -5,20 +5,11 @@ machine:
     PATH: "$HOME/go/bin:$PATH"
     GODIST: "go1.7.1.linux-amd64.tar.gz"
     IMPORT_PATH: "github.com/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME"
-    LIBGIT2VERSION: "0.24.2"
-    LIBGIT2DIST: "libgit2-$LIBGIT2VERSION.tar.gz"
   post:
     - mkdir -p download
     - test -e download/$GODIST || curl -o download/$GODIST https://storage.googleapis.com/golang/$GODIST
     - tar -C $HOME -xzf download/$GODIST
     - sudo apt-get install -y pkgconf cmake
-    - test -e download/v0.24.2.tar.gz || curl -o download/$LIBGIT2DIST https://codeload.github.com/libgit2/libgit2/tar.gz/v$LIBGIT2VERSION
-    - tar -C ~/download -xzf ~/download/$LIBGIT2DIST
-    - test -e ~/download/libgit2-$LIBGIT2VERSION/build || mkdir ~/download/libgit2-$LIBGIT2VERSION/build
-    - cd ~/download/libgit2-$LIBGIT2VERSION/build && cmake ..
-    - cd ~/download/libgit2-$LIBGIT2VERSION/build && cmake --build .
-    - cd ~/download/libgit2-$LIBGIT2VERSION/build && cmake .. -DCMAKE_INSTALL_PREFIX=/usr
-    - cd ~/download/libgit2-$LIBGIT2VERSION/build && sudo cmake --build . --target install
     - test -e ~/.go_workspace/src/github.com/mobingilabs || mkdir -p ~/.go_workspace/src/github.com/mobingilabs
     - test -e ~/.go_workspace/src/github.com/mobingilabs/go-modaemon || ln -s ~/go-modaemon ~/.go_workspace/src/github.com/mobingilabs
 

--- a/code/git.go
+++ b/code/git.go
@@ -1,6 +1,6 @@
 package code
 
-import git "gopkg.in/libgit2/git2go.v24"
+import "os/exec"
 
 type Git struct {
 	url  string
@@ -9,7 +9,5 @@ type Git struct {
 }
 
 func (g *Git) get() error {
-	options := &git.CloneOptions{CheckoutBranch: g.ref}
-	_, err := git.Clone(g.url, g.path, options)
-	return err
+	return exec.Command("git", "clone", "-b", g.ref, g.url, g.path).Run()
 }

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: 290d75c8452e95d893bbddf11d7225788c2115ee57af59f2ea3693a95afb97bd
-updated: 2016-11-14T15:38:55.560831179+09:00
+updated: 2016-11-21T13:31:37.286396135+09:00
 imports:
 - name: github.com/docker/distribution
   version: 93a48e361cbe06d1e77e9d17d02fa6db192a8ca5
@@ -23,6 +23,7 @@ imports:
   - api/types/time
   - api/types/versions
   - client
+  - opts
   - pkg/tlsconfig
 - name: github.com/docker/go-connections
   version: f512407a188ecb16f31a33dbc9c4e4814afc1b03
@@ -62,6 +63,4 @@ imports:
   version: c200b10b5d5e122be351b67af224adc6128af5bf
   subpackages:
   - windows
-- name: gopkg.in/libgit2/git2go.v24
-  version: 22091886372e73de5d66168e8665775676ec13c5
 testImports: []


### PR DESCRIPTION
libgit2 are less portable, so change to use git command.

Ref: https://github.com/mobingilabs/go-modaemon-issues/issues/13
