### PR TITLE
Add check whether /srv/code exists

### DIFF
--- a/code/code.go
+++ b/code/code.go
@@ -43,6 +43,9 @@ func New(s *serverConfig.Config) *Code {
 
 func (c *Code) CheckUpdate() (bool, error) {
 	base := "/srv/code"
+	if !util.FileExists(base) {
+		return true, nil
+	}
 
 	dirs, err := ioutil.ReadDir(base)
 


### PR DESCRIPTION
Because, if `go-modaemon update` is executed when `/srv/code` does not exist, it will get an error.
